### PR TITLE
refactor: use Go 1.21+ stdlib (slices, builtin min, strings.Cut)

### DIFF
--- a/lib/format.go
+++ b/lib/format.go
@@ -166,10 +166,3 @@ func (e *ParseError) Error() string {
 func (e *ParseError) Unwrap() error {
 	return e.Err
 }
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,6 +1,7 @@
 package mq
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/yuin/goldmark/ast"
@@ -59,7 +60,7 @@ func (s *Section) GetCodeBlocks(languages ...string) []*CodeBlock {
 
 	// Return stored code blocks for this section
 	for _, cb := range s.codeBlocks {
-		if len(languages) == 0 || contains(languages, cb.Language) {
+		if len(languages) == 0 || slices.Contains(languages, cb.Language) {
 			blocks = append(blocks, cb)
 		}
 	}
@@ -131,14 +132,6 @@ type ListItem struct {
 }
 
 // helper functions
-func contains(slice []string, item string) bool {
-	for _, s := range slice {
-		if s == item {
-			return true
-		}
-	}
-	return false
-}
 
 func extractText(node ast.Node, buf *strings.Builder) {
 	if node == nil {

--- a/main.go
+++ b/main.go
@@ -365,20 +365,19 @@ func parseMethodCall(query string) (method string, arg string, ok bool) {
 		return "", "", false
 	}
 
-	// Find opening paren
-	parenIdx := strings.Index(query, "(")
-	if parenIdx == -1 {
-		// No paren, just method name like ".tree"
-		return query[1:], "", true
+	query = query[1:]
+
+	method, rest, found := strings.Cut(query, "(")
+	if !found {
+		return method, "", true
 	}
 
 	// Must end with closing paren
-	if !strings.HasSuffix(query, ")") {
+	if !strings.HasSuffix(rest, ")") {
 		return "", "", false
 	}
 
-	method = query[1:parenIdx]
-	arg = query[parenIdx+1 : len(query)-1]
+	arg = strings.TrimSuffix(rest, ")")
 
 	// Strip quotes from arg if present (handle ", ', or no quotes)
 	if len(arg) >= 2 {


### PR DESCRIPTION
## Summary

Modernize codebase to use Go 1.21+ standard library features.

### Changes

1. **Remove manual `min()` helper** (`lib/format.go`)
   - Go 1.21+ has a builtin `min` function

2. **Use `slices.Contains`** (`lib/types.go`)
   - Replaced manual `contains()` helper with `slices.Contains`

3. **Use `strings.Cut`** (`main.go`)
   - Refactored `parseMethodCall` to use `strings.Cut`

## Testing

- All existing tests pass
- Build succeeds
- No behavior changes

## Impact

- **15 lines removed**
- **Risk:** Very low

Closes #1, #2, #3