### PR TITLE
refactor: consolidate duplicate langCounts patterns

### DIFF
--- a/lib/operators.go
+++ b/lib/operators.go
@@ -265,6 +265,18 @@ func MapCodeBlocksToContent(blocks []*CodeBlock) []string {
 	})
 }
 
+func CountCodeByLanguage(blocks []*CodeBlock) map[string]int {
+	counts := make(map[string]int)
+	for _, cb := range blocks {
+		lang := cb.Language
+		if lang == "" {
+			lang = "plain"
+		}
+		counts[lang]++
+	}
+	return counts
+}
+
 // HeadingPredicate creates a predicate for filtering headings.
 type HeadingPredicate func(*Heading) bool
 

--- a/lib/tree.go
+++ b/lib/tree.go
@@ -93,16 +93,7 @@ func (d *Document) buildSectionTree(section *Section, mode TreeMode) *TreeNode {
 		// Code blocks in this section (not children)
 		codeBlocks := section.codeBlocks
 		if len(codeBlocks) > 0 {
-			// Group by language
-			langCounts := make(map[string]int)
-			for _, cb := range codeBlocks {
-				lang := cb.Language
-				if lang == "" {
-					lang = "plain"
-				}
-				langCounts[lang]++
-			}
-			for lang, count := range langCounts {
+			for lang, count := range CountCodeByLanguage(codeBlocks) {
 				meta := fmt.Sprintf("%d block", count)
 				if count > 1 {
 					meta = fmt.Sprintf("%d blocks", count)

--- a/mql/compiler.go
+++ b/mql/compiler.go
@@ -1284,16 +1284,7 @@ func buildSectionNode(section *mq.Section, mode mq.TreeMode) *mq.TreeNode {
 	if mode == mq.TreeModeDefault {
 		codeBlocks := section.GetCodeBlocks()
 		if len(codeBlocks) > 0 {
-			// Group by language
-			langCounts := make(map[string]int)
-			for _, cb := range codeBlocks {
-				lang := cb.Language
-				if lang == "" {
-					lang = "plain"
-				}
-				langCounts[lang]++
-			}
-			for lang, count := range langCounts {
+			for lang, count := range mq.CountCodeByLanguage(codeBlocks) {
 				meta := fmt.Sprintf("%d block", count)
 				if count > 1 {
 					meta = fmt.Sprintf("%d blocks", count)


### PR DESCRIPTION
## Summary
- Extract `CountCodeByLanguage` helper to `lib/operators.go`
- Reuse in `lib/tree.go` and `mql/compiler.go`
- DRY, single source of truth

Closes #7