### PR TITLE
refactor: make zero values meaningful for Line/Start/End fields

### DIFF
--- a/lib/parser.go
+++ b/lib/parser.go
@@ -129,6 +129,9 @@ func (p *Parser) buildIndexes(doc *Document) error {
 			if lines := node.Lines(); lines.Len() > 0 {
 				heading.Line = getLineNumber(lineStarts, lines.At(0).Start)
 			}
+			if heading.Line == 0 {
+				heading.Line = 1
+			}
 
 			// Add to heading indexes
 			doc.headingIndex[heading.Text] = heading

--- a/lib/tree.go
+++ b/lib/tree.go
@@ -19,6 +19,15 @@ const (
 	TreeModeFull    TreeMode = "full"    // Headings + first few words (for directories: expand + preview)
 )
 
+// FormatLineRange formats start/end line numbers for display.
+// End=0 means "extends to end of document" and displays as "start+".
+func FormatLineRange(start, end int) string {
+	if end == 0 {
+		return fmt.Sprintf("%d+", start)
+	}
+	return fmt.Sprintf("%d-%d", start, end)
+}
+
 // TreeNode represents a node in the document structure tree.
 type TreeNode struct {
 	Type     string      // "section", "code", "table", "list", "link", "image", "frontmatter"
@@ -207,8 +216,8 @@ func (t *TreeResult) renderNode(buf *strings.Builder, node *TreeNode, prefix str
 	switch node.Type {
 	case "section":
 		levelPrefix := strings.Repeat("#", node.Level)
-		buf.WriteString(fmt.Sprintf("%s%s%s %s (%d-%d)\n",
-			prefix, connector, levelPrefix, node.Text, node.Start, node.End))
+		buf.WriteString(fmt.Sprintf("%s%s%s %s (%s)\n",
+			prefix, connector, levelPrefix, node.Text, FormatLineRange(node.Start, node.End)))
 
 		// Render preview if available
 		if node.Preview != "" {
@@ -290,7 +299,7 @@ func (d *Document) Search(query string) *SearchResults {
 			results.Matches = append(results.Matches, &SearchResult{
 				File:    d.path,
 				Section: section.Heading.Text,
-				Lines:   fmt.Sprintf("%d-%d", section.Start, section.End),
+				Lines:   FormatLineRange(section.Start, section.End),
 				Match:   snippet,
 			})
 		}

--- a/lib/types.go
+++ b/lib/types.go
@@ -32,24 +32,34 @@ type Section struct {
 	codeBlocks []*CodeBlock // Code blocks in this section (not children)
 }
 
-// GetText extracts the raw markdown content from the section using line numbers.
+// GetText extracts the raw markdown content from the section.
+// Start=0 defaults to 1 (document start), End=0 means extends to document end.
 func (s *Section) GetText() string {
-	if s.source == nil || s.Start == 0 || s.End == 0 {
+	if s.source == nil {
 		return ""
 	}
 
 	lines := strings.Split(string(s.source), "\n")
-	if s.Start > len(lines) {
+	totalLines := len(lines)
+
+	start := s.Start
+	if start == 0 {
+		start = 1
+	}
+	if start > totalLines {
 		return ""
 	}
 
 	end := s.End
-	if end > len(lines) {
-		end = len(lines)
+	if end == 0 || end > totalLines {
+		end = totalLines
 	}
 
-	// Extract lines (1-indexed to 0-indexed)
-	sectionLines := lines[s.Start-1 : end]
+	if end < start {
+		return ""
+	}
+
+	sectionLines := lines[start-1 : end]
 	return strings.Join(sectionLines, "\n")
 }
 

--- a/main.go
+++ b/main.go
@@ -586,7 +586,7 @@ func displayResult(result interface{}) {
 
 	case *mq.Section:
 		fmt.Printf("Section: %s\n", v.Heading.Text)
-		fmt.Printf("Lines: %d-%d\n", v.Start, v.End)
+		fmt.Printf("Lines: %s\n", mq.FormatLineRange(v.Start, v.End))
 		if len(v.Children) > 0 {
 			fmt.Printf("Children: %d\n", len(v.Children))
 			for _, child := range v.Children {
@@ -597,7 +597,7 @@ func displayResult(result interface{}) {
 	case []*mq.Section:
 		fmt.Printf("Found %d sections:\n", len(v))
 		for i, s := range v {
-			fmt.Printf("%d. %s (lines %d-%d)\n", i+1, s.Heading.Text, s.Start, s.End)
+			fmt.Printf("%d. %s (lines %s)\n", i+1, s.Heading.Text, mq.FormatLineRange(s.Start, s.End))
 		}
 
 	case []*mq.CodeBlock:

--- a/mql/compiler.go
+++ b/mql/compiler.go
@@ -1247,9 +1247,14 @@ func toInt(v interface{}) (int, bool) {
 
 // buildSectionTree builds a tree result for a single section.
 func buildSectionTree(section *mq.Section, mode mq.TreeMode) *mq.TreeResult {
+	lines := 0
+	if section.End > 0 && section.End >= section.Start {
+		lines = section.End - section.Start + 1
+	}
+
 	result := &mq.TreeResult{
 		Path:  section.Heading.Text,
-		Lines: section.End - section.Start + 1,
+		Lines: lines,
 		Mode:  mode,
 	}
 


### PR DESCRIPTION
## Summary

Fix section End line numbers by ensuring `heading.Line >= 1` at source, eliminating the need for defensive conditionals downstream.

Go-idiomatic approach: zero values are meaningful rather than invalid. `End=0` means "extends to end of document", handled throughout the stack.

## Changes

| File | Change |
|------|--------|
| `lib/parser.go` | Add fallback ensuring `heading.Line >= 1` |
| `lib/types.go` | `Section.GetText()` handles `Start=0` and `End=0` gracefully |
| `lib/tree.go` | Add `FormatLineRange` helper, `End=0` displays as `N+` |
| `main.go` | Use `FormatLineRange` for section display |
| `mql/compiler.go` | Handle `End=0` in Lines arithmetic |
| `lib/mq_test.go` | Add tests for line number validity |

## Testing

All tests pass:
```
ok  	github.com/muqsitnawaz/mq/lib	0.151s
ok  	github.com/muqsitnawaz/mq/mql	(cached)
```

New tests:
- `TestSectionLineNumbers`: Verifies no section has negative End/Start
- `TestFormatLineRange`: Verifies display helper handles all cases

## Relation to Other Work

- Relates: fork issue #13
- Alternative approach to upstream PR #3 (which uses defensive conditionals)

This is the "do it right" approach - fix at source + belt-and-suspenders validation, rather than defensive cleanup.